### PR TITLE
Add support for Ubuntu 14.04 (trusty)

### DIFF
--- a/jenkins-slave/Dockerfile
+++ b/jenkins-slave/Dockerfile
@@ -1,13 +1,14 @@
 # This Dockerfile is used to build an image containing basic stuff to be used as a Jenkins slave build node.
-FROM ubuntu:latest
+FROM ubuntu:trusty
 MAINTAINER Ervin Varga <ervin.varga@gmail.com>
 
 # Make sure the package repository is up to date.
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe" > /etc/apt/sources.list
+RUN echo "deb http://archive.ubuntu.com/ubuntu trusty main universe" > /etc/apt/sources.list
 RUN apt-get update
 
 # Install a basic SSH server
 RUN apt-get install -y openssh-server
+RUN sed -i 's|session    required     pam_loginuid.so|session    optional     pam_loginuid.so|g' /etc/pam.d/sshd
 RUN mkdir -p /var/run/sshd
 
 # Install JDK 7 (latest edition)


### PR DESCRIPTION
Because the Dockerfile starts from ubuntu:latest, it recently started grabbing 14.04 (trusty) instead of 12.04 (precise).

The sources list line was locked to precise, which prevented building because of dependencies.  Also, changes to the PAM configuration of sshd resulted in shell sessions being killed immediately.  This is addressed by making pam_loginuid optional instead of required.

This PR locks the Dockerfile to trusty (which should be "latest stable" for ~2 years) - I'm sure that the 16/V release of Ubuntu will need some manual TLC to get it working, assuming that the world of containers and jenkins hasn't been re-invented by then.
